### PR TITLE
[WEBMCP-4]: Issue new token for the session, and throw away registration token

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,15 @@ A proposal and code for websites to support client side LLMs
 
 ![NPM Version](https://img.shields.io/npm/v/%40jason.today%2Fwebmcp) ![MIT licensed](https://img.shields.io/npm/l/%40jason.today%2Fwebmcp)
 
-WebMCP allows websites to share tools, resources, prompts, etc. to LLMs. In other words, WebMCP allows a website to be  an MCP server. No sharing API Keys. Use any model you want.
+WebMCP allows websites to share tools, resources, prompts, etc. to LLMs. In other words, WebMCP allows a website to be an MCP server. No sharing API Keys. Use any model you want.
 
 [Here's a simple website I built that is WebMCP-enabled](https://webmcp.jason.today)
 
-It comes in the form of a widget that a website owner can put on their site and give client-side LLMs what they need to provide a great UX for the user or agent.
-
-To initiate a connection, the user generates a token with an unique identifier and connection information and provides it to the input in the widget. The widget then talks to the locally hosted websocket using that information and the server validates the information and establishes a connection. If the user navigates away, they have a grace period to reconnect without needing to reauthenticate (especially useful for multi-page apps / navigation).
-
-You can connect to any number of websites at a time - and tools are "scoped" (by name) based on the domain to simplify organization.
+It comes in the form of a widget that a website owner can put on their site and expose tools to give client-side LLMs what they need to provide a great UX for the user or agent.
 
 _The look, feel, how it's used, and security are all absolutely open for contribution / constructive criticism. MCP Clients directly building WebMCP functionality seems like an ideal outcome._
+
+An end-user can connect to any number of websites at a time - and tools are "scoped" (by name) based on the domain to simplify organization.
 
 # Demo (Sound on 🔊)
 
@@ -36,18 +34,14 @@ To use WebMCP, simply include [`webmcp.js`](https://github.com/jasonjmcghee/WebM
 <script src="webmcp.js"></script>
 ```
 
-The WebMCP widget will automatically initialize and appear in the bottom right corner of your page.
+The WebMCP widget will automatically initialize and appear in the bottom right corner of your page. Clicking on it will ask for a webmcp token which the end-user will generate.
 
 
 ## Getting started (using your LLM with websites using WebMCP)
 
-Install + first time setup
-
-```bash
-npx @jason.today/webmcp@latest
-```
-
 Update your MCP client's config to execute the mcp server by passing `--mcp` to the main binary.
+
+_By adding `-y` and `@latest` as demonstrated below, it will also auto-install and auto-update. Otherwise, you'll need to manually execute the command `npx @jason.today/webmcp` first._
 
 For example, in claude desktop config:
 
@@ -66,34 +60,32 @@ For example, in claude desktop config:
 }
 ```
 
-When you're ready to connect to a website, it'll ask you for a token. This is how you generate one.
-(If your server was not running, this will also start it.)
+When you're ready to connect to a website, you can ask your model to generate you an mcp token.
 
-```bash
-npx @jason.today/webmcp --new
-```
+Copy the token and paste it to the website's input. As soon as the website registers with it, it's thrown away and cannot be used for subsequent registrations or anything else. The website will receive its own session token for making requests.
 
-Copy the token and paste it to the website's input. As soon as the website registers with it, it cannot be used for subsequent registrations (just generate a new one, when you need to).
+If you'd rather your model / service never see the token, you can manually execute `npx @jason.today/webmcp --new` instead.
+
+Some MCP clients, including Claude Desktop, need to be restarted to get access to new tools. (at least at time of writing)
 
 To disconnect, you can close the browser tab, click "disconnect", or shut down the server.
 
-For more information on the server, feel free to run:
-
-```bash
-npx @jason.today/webmcp --help
-```
-
 All configuration files are stored in `~/.webmcp` directory.
 
-## How It Works
+## More Info About How It Works
 
-1. The server generates a registration token with the `--new` command
-2. Web clients connect to the `/register` endpoint with this token and its domain.
-3. Web pages connect to their assigned channel based on their domain.
-4. The MCP client connects to the `/mcp` path using the server token from `.env` (auto-generated)
+1. The MCP client connects to the `/mcp` path using the server token from `.env` (auto-generated)
+2. The server generates a registration token (instigated via the built-in mcp tool by a model or the `--new` command)
+3. Web clients connect to the `/register` endpoint with this token and its domain.
+4. Web pages connect to their assigned channel based on their domain.
 5. When an LLM wants to use a tool / resource / prompt, the request flows from:
    - MCP Client → MCP Server → WebSocket Server → Web Page with the tool / resource / prompt
    - (similar for requesting a list of tools / resources / prompts)
 6. The web page performs the request (e.g. call tool) and sends the result back through the same path
 7. Multiple web pages can be connected simultaneously, each with their own set of tools and tokens
 8. The MCP client sees all tools as a unified list, with channel prefixes to avoid name collisions
+
+## Security
+
+This is a super early project. I'm very interested in hardening security to prevent malicious extensions etc. from being
+able to perform prompt injection attacks and similar. If you have constructive ideas, please reach out or open an issue.

--- a/src/websocket-server.js
+++ b/src/websocket-server.js
@@ -223,20 +223,23 @@ wss.on('connection', (ws, req) => {
                     return;
                 }
 
-                // Authorize the channel-token pair
-                setToken(channelPath, token);
+                // Throw away registration token and make a session token.
                 deleteToken(serverChannel);
-                await saveAuthorizedTokens();
+                const sessionToken = generateToken();
 
-                console.error(`Registered channel: ${channelPath} with token: ${token}`);
+                // Authorize the channel-token pair
+                setToken(channelPath, sessionToken);
+                await saveAuthorizedTokens();
 
                 // Send success response
                 ws.send(JSON.stringify({
                     type: 'registerSuccess',
                     channel: channelPath,
                     message: `Registration successful for ${channelPath}`,
-                    token: token
+                    token: sessionToken
                 }));
+
+                console.error(`Registered channel: ${channelPath} with token: ${token}`);
 
                 // Close the registration connection - they'll reconnect to their channel
                 ws.close(1000, 'Registration complete');


### PR DESCRIPTION
Fixes #4 

So now we immediately throw away the registration token, instead of reusing it for the session.

Also improves README.