### PR TITLE
  Fix Windows daemon crash when stdin is not a TTY

### DIFF
--- a/src/websocket-server.js
+++ b/src/websocket-server.js
@@ -1502,7 +1502,7 @@ const main = async () => {
     process.on('SIGTERM', () => shutdownGracefully('SIGTERM'));
 
     // Enable keyboard input handling for CTRL+C on Windows
-    if (process.platform === 'win32') {
+    if (process.platform === 'win32' && process.stdin.isTTY) {
         process.stdin.setRawMode(true);
         process.stdin.resume();
         process.stdin.on('data', (data) => {


### PR DESCRIPTION
  process.stdin.setRawMode() is only available on TTY streams.
  When spawned by MCP clients (e.g. via child_process with piped stdio),
  stdin is not a TTY and the daemon crashes immediately.
  Add process.stdin.isTTY guard before calling setRawMode.